### PR TITLE
Add hidden version label field

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -900,4 +900,6 @@ export default Ember.Component.extend(ClusterDriver, {
     set(this, 'step', Steps.disk)
     cb(true)
   },
+
+  version: '%%DRIVERVERSION%%',
 })

--- a/component/template.hbs
+++ b/component/template.hbs
@@ -1,5 +1,7 @@
 <section class="horizontal-form">
 
+  <label hidden="hidden" id="version">OpenTelekomCloud CCE driver UI {{version}}</label>
+
   {{#accordion-list showExpandAll=(eq mode "edit") as | al expandFn |}}
     {{#accordion-list-item title=(t 'cluster.auth.title')
                            expand=(action expandFn)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,16 +12,23 @@ const fs = require('fs');
 const replaceString = require('replace-string');
 
 const NAME_TOKEN = '%%DRIVERNAME%%';
+const VERSION_TOKEN = '%%DRIVERVERSION%%';
 const BASE = 'component/';
 const DIST = 'dist/';
 const TMP = 'tmp/';
 const ASSETS = 'assets/';
-const DRIVER_NAME = 'otccce';
+const DRIVER_NAME = argv.name;
+const DRIVER_VERSION = argv['ui-version'];
 
 console.log('Driver Name:', DRIVER_NAME);
+console.log('Driver Version:', DRIVER_VERSION);
 
 if (!DRIVER_NAME) {
   console.log('Please include a driver name with the --name flag');
+  process.exit(1);
+}
+if (!DRIVER_VERSION) {
+  console.log('Please include a driver version with the --ui-version flag');
   process.exit(1);
 }
 
@@ -33,6 +40,7 @@ gulp.task('clean', function () {
 gulp.task('styles', gulp.series('clean', function () {
   return gulp.src([`${BASE}**.css`])
     .pipe(replace(NAME_TOKEN, DRIVER_NAME))
+    .pipe(replace(VERSION_TOKEN, DRIVER_VERSION))
     .pipe(gulpConcat(`component.css`, { newLine: '\n' }))
     .pipe(gulp.dest(DIST));
 }));
@@ -75,11 +83,12 @@ gulp.task('babel', gulp.series('assets', function () {
     `${BASE}component.js`
   ])
     .pipe(include({
-      extensions:   'js',
+      extensions: 'js',
     }))
     .on('error', console.log)
     .pipe(replace('const LAYOUT;', `const LAYOUT = '${hbs}';`))
     .pipe(replace(NAME_TOKEN, DRIVER_NAME))
+    .pipe(replace(VERSION_TOKEN, DRIVER_VERSION))
     .pipe(babel(opts))
     .pipe(gulpConcat(`component.js`, { newLine: '\n' }))
     .pipe(gulp.dest(TMP));


### PR DESCRIPTION
You can now find version searching for `#version` in DOM:
![image](https://user-images.githubusercontent.com/8591561/96443508-6438f680-1215-11eb-98d7-6b0f98d28375.png)


Add build argument `--ui-version`

Make `--name` build argument required