### PR TITLE
Add workaround for pretty OTC CCE name

### DIFF
--- a/component/component.css
+++ b/component/component.css
@@ -1,3 +1,9 @@
 .machine-driver.%%DRIVERNAME%% {
   background-image: url('otc.png');
 }
+a[href$="%%DRIVERNAME%%"] .driver-content>.driver-name {
+  display: none;
+}
+a[href$="%%DRIVERNAME%%"] .driver-content:after {
+  content: 'Open Telekom Cloud CCE';
+}


### PR DESCRIPTION
Question:
Should we use this solution?

![image](https://user-images.githubusercontent.com/8591561/96554341-17a9f580-12bf-11eb-9310-4bc1b271af00.png)

@kucerakk @vladimirhasko What is your opinion about this workaround?