### PR TITLE
Add passing name and version from config to gulp build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "start": "./node_modules/.bin/gulp server",
     "clean": "./node_modules/.bin/gulp clean",
-    "build": "./node_modules/.bin/gulp build",
+    "build": "./node_modules/.bin/gulp build --name otccce --ui-version ${npm_package_version}",
     "upload": "./scripts/upload"
   },
   "homepage": "",


### PR DESCRIPTION
```bash
$ npm run build 

> ui-cluster-driver-otc@0.0.1 build /home/akachuri/PycharmProjects/ui-cluster-driver-otc
> gulp build --name otccce --ui-version ${npm_package_version}

Driver Name: otccce
Driver Version: 0.0.1
```