### PR TITLE
deprecation and package.json update

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -4,6 +4,8 @@
     name: js-build-ubuntu
     parent: js-build
     nodeset: ubuntu-jammy
+    vars:
+      node_version: v20.19.3
 
 - project:
     merge-mode: squash-merge

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -5,7 +5,7 @@
     parent: js-build
     nodeset: ubuntu-jammy
     vars:
-      node_version: v20.19.3
+      node_version: 20
 
 - project:
     merge-mode: squash-merge

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -3,7 +3,7 @@
 - job:
     name: js-build-ubuntu
     parent: js-build
-    nodeset: ubuntu-focal
+    nodeset: ubuntu-jammy
 
 - project:
     merge-mode: squash-merge

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Frontend part of OpenTelekomCloud CCE driver for Rancher
 
+**Note**: Support for UI Plugins (based on Ember) for cluster and node drivers was deprecated in Rancher 2.11.0 and will be removed in a future release.
+
 Backend part:
  - https://github.com/opentelekomcloud/kontainer-engine-driver-otc
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,21 @@
 {
-  "name": "ui-cluster-driver-otccce",
-  "version": "1.1.2-rc.1",
+  "name": "@opentelekomcloud/ui-cluster-driver-otccce",
+  "version": "1.1.3",
   "description": "OpenTelekomCloud CCE driver",
   "repository": {
     "type": "git",
     "url": "https://github.com/opentelekomcloud/ui-cluster-driver-otc"
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist/",
+    "component/",
+    "assets/",
+    "README.md",
+    "LICENSE"
+  ],
   "author": "T-Systems GmbH",
   "license": "Apache-2.0",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelekomcloud/ui-cluster-driver-otccce",
-  "version": "1.1.3",
+  "version": "1.2.1",
   "description": "OpenTelekomCloud CCE driver",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Support for UI Plugins (based on Ember) for cluster and node drivers was deprecated in Rancher 2.11.0 and will be removed in a future release.